### PR TITLE
Update set_fact.sh to support multiple network

### DIFF
--- a/files/set_facts.sh
+++ b/files/set_facts.sh
@@ -6,7 +6,7 @@ NETWORKS=$(zerotier-cli listnetworks | tail -n+2)
 
 function file_content {
     if [ ! -z "$NETWORKS" ]; then
-        network_count=$(echo $NETWORKS |wc -l)
+        network_count=$(echo "$NETWORKS" |wc -l)
         counter=1
 
         echo "{"


### PR DESCRIPTION
Currently the role will fail to regather fact if $network_count > 1

That's because without the quotes echo will suppress the \n writing everything in one line. Thus wc -l will return `1`, confusing the file_content function that will lead to an incorrect json being produced